### PR TITLE
Added where LINQ clause to filter out empty strings from originConfigs.

### DIFF
--- a/Samples/ServiceAPI/CSharp/CORSModule/CORSModule.cs
+++ b/Samples/ServiceAPI/CSharp/CORSModule/CORSModule.cs
@@ -21,7 +21,7 @@ public class CORSModule : IHttpModule
         var originConfigs = ConfigurationManager.AppSettings["allowedOrigins"];
 
 
-        this.origins = (originConfigs ?? "").Split(',').Select(o => o.Trim()).ToArray();
+        this.origins = (originConfigs ?? "").Split(',').Select(o => o.Trim()).Where(o => !string.IsNullOrEmpty(o)).ToArray();
 
         context.PreSendRequestHeaders += delegate
         {


### PR DESCRIPTION
Hey there,

I set out to use this CORS module for the Content Manager Service API but found that there was a problem with it.

In the [readme ](https://github.com/content-manager-sdk/Community/blob/master/Samples/ServiceAPI/CSharp/CORSModule/ReadMe.md)it states that:

> if you do not set 'allowedOrigins' in app settings than all domains will be allowed to use CORS (Access-Control-Allow-Origin = "*")

However, the if statement that allows this logic did not work because there was always at least one string in the origins array (an empty one, if 'allowedOrigins' is not set). 

Therefore, I've added a Where LINQ clause that ensures that no empty strings end up in this array, meaning that the if statement is hit and it does apply the default behaviour of allowing all origins.

I have tested this all with Content manager 9.3. CORS requests from any domain are now able to succeed when 'allowedOrigins' is not set or has an empty value, and specific domains can still be allowed as well if that is what is required.